### PR TITLE
fix: babel error - closes #11

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,7 @@ src/
 
 build/
 DerivedData
+
+.babelrc
+
+.idea


### PR DESCRIPTION
ignore .babelrc as discussed here https://github.com/BBB/react-native-card.io/issues/11
ignore .idea as the folder currently comes when installing via npm
